### PR TITLE
Add option to Name Zettel Note filename by title

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ basic wiki and navigate it.
   %title Note title
   %date current date
   ```
+  where title is the first parameter to `:ZettelNew`.
+  You can also set the filename to include the title by toggling the variable `g:zettel_filename_title=1`.
 
 - `:ZettelBackLinks` command – insert list of notes that link to the current note.
 

--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -138,7 +138,7 @@ function! zettel#vimwiki#template(title, date)
 endfunction
 
 function! zettel#vimwiki#new_zettel_name(...)
-  if a:1 != ""
+  if a:0 > 0 && a:1 != "" && g:zettel_filename_title
       return strftime(g:zettel_format) . "-" . a:1
   endif
 

--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -137,7 +137,11 @@ function! zettel#vimwiki#template(title, date)
   call <sid>add_line(s:header_delimiter)
 endfunction
 
-function! zettel#vimwiki#new_zettel_name()
+function! zettel#vimwiki#new_zettel_name(...)
+  if a:1 != ""
+      return strftime(g:zettel_format) . "-" . a:1
+  endif
+
   return strftime(g:zettel_format)
 endfunction
 
@@ -261,7 +265,7 @@ endfunction
 " there is one optional argument, the zettel title
 function! zettel#vimwiki#create(...)
   " name of the new note
-  let format = zettel#vimwiki#new_zettel_name()
+  let format = zettel#vimwiki#new_zettel_name(a:1)
   let date_format = strftime("%Y-%m-%d %H:%M")
   echom("new zettel: ". format)
   let link_info = vimwiki#base#resolve_link(format)

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -92,6 +92,10 @@ if !exists('g:zettel_default_mappings')
   let g:zettel_default_mappings=1
 endif
 
+if !exists('g:zettel_filename_title')
+    let g:zettel_filename_title=0
+endif
+
 nnoremap <silent> <Plug>ZettelSearchMap :ZettelSearch<cr>
 nnoremap <silent> <Plug>ZettelYankNameMap :ZettelYankName<cr> 
 nnoremap <silent> <Plug>ZettelReplaceFileWithLink :call <sid>replace_file_with_link()<cr> 


### PR DESCRIPTION
Hello,

Thank you for developing this plugin. Would you be interested in considering my modification? It allows the filename to be appended with the title, and if there is no title passed it won't append it. It is just easier for me when I am searching my notes to give me more context into what the note was for. 

If you would be interested in this modification, I can fine-tune it and add a global variable so this behaviour is user-set through a config variable.

Let me know your thoughts,

- Hristo