### PR TITLE
Minor improvements to UX

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -140,7 +140,7 @@ endfunction
 
 " sanitize title for filename
 function! zettel#vimwiki#escape_filename(name)
-  let name = substitute(a:name, " ", "_","") " change spaces to underscores
+  let name = substitute(a:name, " ", "_","g") " change spaces to underscores
   let name = tolower(name)
   return fnameescape(name)
 endfunction
@@ -326,8 +326,6 @@ function! zettel#vimwiki#zettel_new(...)
   if filename == 0
     return 0
   endif
-  " save the new wiki file
-  execute ":w"
   let front_matter = zettel#vimwiki#get_option("front_matter")
   if !empty(front_matter)
     let newfile = zettel#vimwiki#save_wiki_page(filename)
@@ -345,6 +343,9 @@ function! zettel#vimwiki#zettel_new(...)
   if !empty(template)
     execute "read " . template
   endif
+
+  " save the new wiki file
+  execute ":w"
 
 endfunction
 

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -33,15 +33,18 @@ function! s:wiki_search(line)
   let title = <sid>get_zettel_title(filename)
   " insert the filename and title into the current buffer
   let wikiname = <sid>get_wiki_file(filename)
+  " if the title is empty, the link will be hidden by vimwiki, use the filename
+  " instead
+  if empty(title)
+    let title = wikiname
+  end
   let link = zettel#vimwiki#format_search_link(wikiname, title)
-  " delete the [[, set mark ` at the current position,  insert selected link and title 
-  execute 'normal! xxm`a'. link 
-  " if the title is empty, the link will be hidden by vimwiki
-  " we can move the cursor to the title position and switch to the insert mode
-  " to enable user to specify the title by hand
-  if title == ""
-    call zettel#vimwiki#insert_mode_in_title()
-  endif
+  let line = getline('.')
+  " replace the [[ with selected link and title
+  let caret = col('.')
+  call setline('.', strpart(line, 0, caret - 2) . link . strpart(line, caret))
+  startinsert
+  call cursor(line('.'), caret + len(link) - 1)
 endfunction
 
 function! s:wiki_yank_name()


### PR DESCRIPTION
This changes some things around:

- Generated filenames use global replace for spaces, instead of first occurrence only.
- Save newly generated file after adding custom front-matter to it.
- Fix `[[` only working at the end of lines.
- Make `[[` leave you in insert mode after adding the link (makes `[[` more like a real autocomplete)

In order to accomplish these I needed to change the behavior for pages without titles. Previously, you would go to insert mode and be able to type a title. Now, for consistency, you are always placed in insert mode at the end of the link. If a page doesn't have a title, the wiki filename is used as the link text.