### PR TITLE
use feedkeys instead of startinsert

### DIFF
--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -41,10 +41,7 @@ function! s:wiki_search(line)
   let link = zettel#vimwiki#format_search_link(wikiname, title)
   let line = getline('.')
   " replace the [[ with selected link and title
-  let caret = col('.')
-  call setline('.', strpart(line, 0, caret - 2) . link . strpart(line, caret))
-  startinsert
-  call cursor(line('.'), caret + len(link) - 1)
+  call feedkeys("a\<BS>\<BS>".link)
 endfunction
 
 function! s:wiki_yank_name()


### PR DESCRIPTION
After playing with the old pull request I noticed it works in terminal vim but not in MacVim. In MacVim, the first keystroke is erroneously treated as a normal mode keystroke (so, e.g. `j` would move the cursor down normally but then immediately place you into insert mode). Looks like this is related, even though it refers to nvim: https://github.com/junegunn/fzf/issues/426

The same workaround there works here, in both terminal vim and macvim.