### PR TITLE
Reposition cursor before appending text

### DIFF
--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -47,7 +47,7 @@ function! s:wiki_search(line)
   " replace the [[ with selected link and title
   let caret = col('.')
   call setline('.', strpart(line, 0, caret - 2) . link .  strpart(line, caret))
-  call cursor(line('.'), caret + len(link) - 1)
+  call cursor(line('.'), caret + len(link) - 2)
   call feedkeys("a", "n")
 endfunction
 


### PR DESCRIPTION
Issue: when inserting a link in the middle of a line of text, the cursor is incorrectly positioned on the character AFTER the link.

Steps to reproduce: From terminal vim in normal mode, type `oxx<Esc>i[[<CR>Z<Esc>`
Expected result: `x[some link](2020...)Zx`
Actual result: `x[some link](2020...)xZ`

For reference, here's the steps to expected behavior when inserting a link at the end of a line.

Steps to reproduce: From terminal vim in normal mode, type `oxx[[<CR>Z<Esc>`
Expected result: `xx[some link](2020...)Z`
Actual result: as expected