### PR TITLE
Breaks ties with match closest to end of line

### DIFF
--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -78,7 +78,7 @@ command! -bang -nargs=* ZettelSearch call <sid>execute_fzf(<q-args>,
       \'down': '~40%',
       \'sink':function('<sid>wiki_search'),
       \'dir':g:zettel_dir,
-      \'options':'--exact'})
+      \'options':'--exact', '--tiebreak=end'})
 
 
 command! -bang -nargs=* ZettelNew call zettel#vimwiki#zettel_new(<q-args>)

--- a/ftplugin/vimwiki.vim
+++ b/ftplugin/vimwiki.vim
@@ -30,8 +30,7 @@ command! -bang -nargs=* ZettelSearch call zettel#fzf#execute_fzf(<q-args>,
       \'down': '~40%',
       \'sink':function('zettel#fzf#wiki_search'),
       \'dir':g:zettel_dir,
-      \'options':'--exact', '--tiebreak=end'})
-      \'options':['--exact']}))
+      \'options': ['--exact', '--tiebreak=end']}))
 
 
 


### PR DESCRIPTION
Using this method means that the search results will favor the text in
the file over the file name. Which makes the results more accurate.