### PR TITLE
Respect `links_space_char` setting from vimwiki

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -180,7 +180,9 @@ endfunction
 " sanitize title for filename
 function! zettel#vimwiki#escape_filename(name)
   let name = substitute(a:name, "[%.%,%?%!%:]", "", "g") " remove unwanted characters
-  let name = substitute(name, " ", "_","g") " change spaces to underscores
+  let schar = vimwiki#vars#get_wikilocal('links_space_char') " ' ' by default
+  let name = substitute(name, " ", schar, "g") " change spaces to link_space_char
+
   let name = tolower(name)
   return fnameescape(name)
 endfunction


### PR DESCRIPTION
vimwiki lets you define a `links_space_char` setting (:h
links_space_char), which lets you specify the separators used in place
of spaces for filenames. vim-zettel, before this patch, simply used `_`
to replace spaces in generated filenames. Now it respects the
`link_space_char` setting.

---

This is a backwards incompatible change, so feel free to reject (or
suggest a work around, like perhaps defining a custom vim-zettel setting
for example).