### PR TITLE
Escapes wikipath when doing backlinks to handle spaces.

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -609,7 +609,10 @@ function! zettel#vimwiki#backlinks()
     " only add backlink if it is not already backlink
     let is_backlink = s:is_in_backlinks(file, current_filename)
     if is_backlink < 1
-      call s:add_bulleted_link(locations, file)
+      " Make sure we don't add ourselves
+      if !(file ==# expand("%:p"))
+        call s:add_bulleted_link(locations, file)
+      endif
     endif
   endfor
 

--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -298,7 +298,7 @@ endfunction
 function! zettel#vimwiki#wikigrep(pattern)
   let paths = []
   let idx = vimwiki#vars#get_bufferlocal('wiki_nr')
-  let path = vimwiki#vars#get_wikilocal('path', idx)
+  let path = fnameescape(vimwiki#vars#get_wikilocal('path', idx))
   let ext = vimwiki#vars#get_wikilocal('ext', idx)
   try
     let command = 'vimgrep ' . a:pattern . 'j ' . path . "*" . ext
@@ -614,7 +614,7 @@ function! zettel#vimwiki#backlinks()
   endfor
 
   if empty(locations)
-    echomsg 'Vimwiki: No other file links to this file'
+    echomsg 'Vimzettel: No other file links to this file'
   else
     call uniq(locations)
     " Insert back links section


### PR DESCRIPTION
My vimwiki path has a space in it, which breaks the command invocation when grepping for backlinks.  This properly escapes the vimwiki path before building the search command.