### PR TITLE
Prevent duplicate file creation

### DIFF
--- a/autoload/zettel/fzf.vim
+++ b/autoload/zettel/fzf.vim
@@ -85,7 +85,7 @@ function! zettel#fzf#search_open(line,...)
     echom("[DEBUG] wikiname: " . wikiname)
     echom("[DEBUG] dir: " . g:zettel_dir)
     echom("[DEBUG] wikidir: " . vimwiki#vars#get_wikilocal('path'))
-    call vimwiki#base#open_link(':e ', wikiname)
+    call vimwiki#base#open_link(':e ', '/'.wikiname)
   endif
 endfunction
 

--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -457,7 +457,7 @@ function! zettel#vimwiki#create(...)
   let wiki_not_exists = s:wiki_file_not_exists(format)
   " let vimwiki to open the wiki file. this is necessary  
   " to support the vimwiki navigation commands.
-  call vimwiki#base#open_link(':e ', format)
+  call vimwiki#base#open_link(':e ', '/'.format)
   " add basic template to the new file
   if wiki_not_exists
     call zettel#vimwiki#template(a:1, date)


### PR DESCRIPTION
When a file in a subfolder is open and `:ZettelNew` is invoked, vim-zettel opens a file in that directory and saves it, and then opens the same filename in the root of the wiki and saves _that_ file, resulting in the same file written to two different locations.

This change forces the create function to always operate in the root to prevent this behavior. I believe this might be an example of a "load bearing bug" and people might have their workflows now relying on the counter-intuitive behavior, so I'd understand choosing to not to change the behavior. I'm sure there are better approaches to solving this, and I'm uncertain if there are other use cases within vim-zettel that this might negatively impact, but this does correct `:ZettelNew`'s behavior against what I think its expectations are.