### PR TITLE
Fallback on regular Markdown heading for the Zettel's title

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -423,13 +423,15 @@ endfunction
 
 function! zettel#vimwiki#get_title(filename)
   let filename = a:filename
-  let title = ""
   let lsource = readfile(filename)
   " this code comes from vimwiki's html export plugin
   for line in lsource 
+    " matches a title in a YAML front matter style
     if line =~# '^\s*%\=title'
-      let title = matchstr(line, '^\s*%\=title:\=\s\zs.*')
-      return title
+      return matchstr(line, '^\s*%\=title:\=\s\zs.*')
+    " matches the first heading of any level found in the note
+    elseif line =~# '^#\{1,6}\s\+\S\+'
+      return matchstr(line, '^#\{1,6}\s\+\zs.\{-}\ze\s*$')
     endif
   endfor 
   return ""


### PR DESCRIPTION
If no YAML front matter is found in a note, the title will be parsed from the first Markdown heading found.

[This is how neuron handles it](https://neuron.zettel.page/metadata.html#other-metadata):

> You can explicitly specify a title using the title metadata; otherwise, Neuron will infer it from the Markdown heading or Zettel ID.

Fixes https://github.com/michal-h21/vim-zettel/issues/79