### PR TITLE
Make #vimwiki#make_random_chars compatible to Vim 8.1

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -150,6 +150,17 @@ function! zettel#vimwiki#make_random_chars()
   return join(str_list, "")
 endfunction
 
+elseif v:version < 802
+function! zettel#vimwiki#make_random_chars()
+  call luaeval("math.randomseed( os.time() )")
+  let char_no = range(g:zettel_random_chars)
+  let str_list = []
+  for x in char_no
+    call add(str_list, nr2char(str2nr(string(luaeval("math.random(97,122)")))))
+  endfor
+  return join(str_list, "")
+endfunction
+
 else
 
 " make string filled with random characters


### PR DESCRIPTION
Adapted vimwiki.vim to work without srand (i.e. version prior to 8.1.2342).

Fixes #81 