### PR TITLE
Make #vimwiki#make_random_chars compatible to Vim 8.1

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -150,6 +150,16 @@ function! zettel#vimwiki#make_random_chars()
   return join(str_list, "")
 endfunction
 
+elseif v:version < 802
+function! zettel#vimwiki#make_random_chars()
+  let char_no = range(g:zettel_random_chars)
+  let str_list = []
+  for x in char_no
+    call add(str_list, nr2char(matchstr(reltimestr(reltime()), '\v\.@<=\d+')%26+97))
+  endfor
+  return join(str_list, "")
+endfunction
+
 else
 
 " make string filled with random characters


### PR DESCRIPTION
Now generates random on vim releases prior to 8.2 without depending on lua.

Fixes #81.