### PR TITLE
using fzf#vim#grep for ag in zettel#fzf#execute_fzf

### DIFF
--- a/autoload/zettel/fzf.vim
+++ b/autoload/zettel/fzf.vim
@@ -37,18 +37,20 @@ endfunction
 " execute fzf function
 function! zettel#fzf#execute_fzf(a, b, options)
   " search only files in the current wiki syntax
-  " it doesn't work with ag searcher
-  let search_ext = "*" . vimwiki#vars#get_wikilocal('ext')
-  " let search_ext = ""
-  " I cannot get `ag` running with fzf#vim#grep, so we use
-  " two different methods
+
+  let l:fullscreen = 0
+
   if g:zettel_fzf_command == "ag"
-    let Fzf_cmd = function("fzf#vim#" . g:zettel_fzf_command)
-    return Fzf_cmd(a:a, a:b, a:options)
+    let search_ext = "--" . substitute(vimwiki#vars#get_wikilocal('ext'), '\.', '', '')
+    let query =  empty(a:a) ? '^(?=.)' : a:a
+    let l:fzf_command = g:zettel_fzf_command . ' --color --smart-case --nogroup --column ' . shellescape(query)  " --ignore-case --smart-case
   else
     " use grep method for other commands
-    return fzf#vim#grep(g:zettel_fzf_command . " " . shellescape(a:a) . " " . search_ext, 1, a:options)
+    let search_ext = "*" . vimwiki#vars#get_wikilocal('ext')
+    let l:fzf_command = g:zettel_fzf_command . " " . shellescape(a:a)
   endif
+
+  return fzf#vim#grep(l:fzf_command . ' ' . search_ext, 1, fzf#vim#with_preview(a:options), l:fullscreen)
 endfunction
 
 

--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -95,7 +95,7 @@ else
   let s:header_format = "%%%s %s"
   let s:header_delimiter = ""
   let s:insert_mode_title_format = "h"
-  let s:grep_link_pattern = '/\[%s[|#]/'
+  let s:grep_link_pattern = '/\[%s[|#\]]/'
   let s:section_pattern = "= %s ="
 end
 

--- a/doc/zettel.txt
+++ b/doc/zettel.txt
@@ -411,6 +411,14 @@ commit changes in wiki and synchronize them with external Git repository.
 ==============================================================================
 8.  Changelog                                            *Vim-Zettel-ChangeLog*
 
+2020-10-22  Doug Ghormley
+
+* autoload/zettel/vimwiki.vim: detect backlinks without titles in links.
+
+2020-10-11  LeducH
+
+* README.md: `vim-plug` install details.
+
 2020-09-24  Michal Hoftich <michal.h21@gmail.com>
 
 * autoload/zettel/fzf.vim: use `'down': '~40%'` option for FZF.


### PR DESCRIPTION
This is not much just using `fzf#vim#grep` for silver-searcher (`ag`) in `zettel#fzf#execute_fzf` as for other search tools

Please check if the behaviour is as expected. 

Cheers,
David

p.s. sorry there seems a commit from you in ...
