### PR TITLE
Change default mappings to buffer local mappings

### DIFF
--- a/ftplugin/vimwiki/zettel.vim
+++ b/ftplugin/vimwiki/zettel.vim
@@ -60,9 +60,9 @@ xnoremap <silent> <Plug>ZettelNewSelectedMap :call zettel#vimwiki#zettel_new_sel
 
 if g:zettel_default_mappings==1
   " inoremap [[ [[<esc>:ZettelSearch<CR>
-  imap <silent> [[ [[<esc><Plug>ZettelSearchMap
-  nmap T <Plug>ZettelYankNameMap
+  imap <buffer> <silent> [[ [[<esc><Plug>ZettelSearchMap
+  nmap <buffer> T <Plug>ZettelYankNameMap
   " xnoremap z :call zettel#vimwiki#zettel_new_selected()<CR>
-  xmap z <Plug>ZettelNewSelectedMap
-  nmap gZ <Plug>ZettelReplaceFileWithLink
+  xmap <buffer> z <Plug>ZettelNewSelectedMap
+  nmap <buffer> gZ <Plug>ZettelReplaceFileWithLink
 endif


### PR DESCRIPTION
Hi!

When I leave the vimwiki buffer and start editing, say, `.lua` file, the `[[` mapping still exists.
In `lua`, `[[` is used for defining unescaped string.

I don't know whether the mapping is intended to be used outside `vimwiki` files or not, so it might not suit the case if we implement buffer-local mapping.
If that's the case, please let me know!

Thanks 😄 