### PR TITLE
Extend title load function to extract title from headlines (fixes #103)

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -426,9 +426,30 @@ function! zettel#vimwiki#get_title(filename)
   let title = ""
   let lsource = readfile(filename)
   " this code comes from vimwiki's html export plugin
+   
+  " Try to load the title from the front matter entry which is present  
+  " at the head of a file. If the front matter is not present use the first
+  " headline as title either in vimwiki or markup style.
   for line in lsource 
+    " Check if front matter title is present
     if line =~# '^\s*%\=title'
       let title = matchstr(line, '^\s*%\=title:\=\s\zs.*')
+      return title
+    endif
+    
+    " Check if first headline is present in vimwiki style
+    " \zs marks the start of the match part
+    " \ze marks the end of the match part
+    if line =~# '^\s*=\s*\S*\s=\s*'
+      let title = matchstr(line, '^\s*=\s*\zs.*\ze\s=\s*')
+      return title
+    endif
+
+    " Check if first headline is present in markdown style
+    " \zs marks the start of the match part
+    " \ze marks the end of the match part
+    if line =~# '^\s*#\s*.*'
+      let title = matchstr(line, '^\s*#\s*\zs.*\ze')
       return title
     endif
   endfor 

--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -440,8 +440,8 @@ function! zettel#vimwiki#get_title(filename)
     " Check if first headline is present in vimwiki style
     " \zs marks the start of the match part
     " \ze marks the end of the match part
-    if line =~# '^\s*=\s*\S*\s=\s*'
-      let title = matchstr(line, '^\s*=\s*\zs.*\ze\s=\s*')
+     if line =~# '^\s*=\s\+.*\S\s\+=\s*'
+      let title = matchstr(line, '^\s*=\s\+\zs.*\S\ze\s\+=\s*')
       return title
     endif
 


### PR DESCRIPTION
If the user is not using the front_matter the plugin was not able to load the title from the first level headline in vimwiki or markdown style. Refer to issue #103

Therefore I extended the zettel#vimwiki#get_title function to load the title from the first level headline in vimwiki or markdown style.

I tested the behavior by deactivating front_matter as follows in my .vimrc and defining a headline using one of the below styles in a new zettel.
`let g:zettel_options = [{"template" :  "~/zettel_template.tpl", "disable_front_matter" : 1}]`

vimwiki style
`= TITLE =`

markdown style
`# TITLE`