### PR TITLE
support arbitrary registers in wiki_yank_name()

### DIFF
--- a/ftplugin/vimwiki/zettel.vim
+++ b/ftplugin/vimwiki/zettel.vim
@@ -7,14 +7,7 @@ endif
 function! s:wiki_yank_name()
   let filename = expand("%")
   let link = zettel#vimwiki#get_link(filename)
-  let clipboardtype=&clipboard
-  if clipboardtype=="unnamed"  
-    let @* = link
-  elseif clipboardtype=="unnamedplus"
-    let @+ = link
-  else
-    let @@ = link
-  endif
+  call setreg(v:register, link)
   return link
 endfunction
 


### PR DESCRIPTION
just a tiny change to allow things like `"aT`