### PR TITLE
Search in sub-directories when using search other than ag

### DIFF
--- a/autoload/zettel/fzf.vim
+++ b/autoload/zettel/fzf.vim
@@ -61,7 +61,7 @@ function! zettel#fzf#execute_fzf(a, b, options)
     let l:fzf_command = g:zettel_fzf_command . ' --color --smart-case --nogroup --column ' . shellescape(query)  " --ignore-case --smart-case
   else
     " use grep method for other commands
-    let search_ext = "*" . vimwiki#vars#get_wikilocal('ext')
+    let search_ext = "**/*" . vimwiki#vars#get_wikilocal('ext')
     let l:fzf_command = g:zettel_fzf_command . " " . shellescape(a:a)
   endif
 


### PR DESCRIPTION
When setting `g:zettel_fzf_command` to something other than `ag`, this
is the smallest change that preserves the search tool looking through
sub-directories.

To test:
1. Have a folder in the zettel directory, with a wiki file in that
folder.
2. Search for some content in that file
3. See that it appears in the fzf matcher

Set the below in your Vim config, and the content will not be in the
fzf-matcher:
```vim
let g:zettel_fzf_command = "rg --column --line-number --ignore-case --no-heading --color=always "
```

Update to use this change and it will be available with the `rg` tool.
