### PR TITLE
Match the changed API of vimwiki#base#check_links

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -870,7 +870,7 @@ function! zettel#vimwiki#backlinks()
 endfunction
 
 function! zettel#vimwiki#inbox()
-  call vimwiki#base#check_links()
+  call vimwiki#base#check_links(0)
   let linklist = getqflist()
   cclose
   let paths = []


### PR DESCRIPTION
The change was in
vimwiki/vimwiki@dede5a1eeaa13474beedd07427ad2869ebe4ca7a to allow it to
work on the current wiki or a range of lines

This change ensures it runs _only_ on the current vimwiki, as was the
case before the API change.
