### PR TITLE
Fix mappings to <Plug> in ViM

### DIFF
--- a/ftplugin/vimwiki/zettel.vim
+++ b/ftplugin/vimwiki/zettel.vim
@@ -62,10 +62,10 @@ xnoremap <silent> <Plug>ZettelTitleSelectedMap :<C-U>ZettelTitleSelected<CR>
 
 if g:zettel_default_mappings==1
   " inoremap [[ [[<esc>:ZettelSearch<CR>
-  inoremap <buffer> <silent> [[ [[<esc><Plug>ZettelSearchMap
-  nnoremap <buffer> T <Plug>ZettelYankNameMap
+  imap <buffer> <silent> [[ [[<esc><Plug>ZettelSearchMap
+  nmap <buffer> T <Plug>ZettelYankNameMap
   " xnoremap z :call zettel#vimwiki#zettel_new_selected()<CR>
-  xnoremap <buffer> z <Plug>ZettelNewSelectedMap
-  xnoremap <buffer> g[ <Plug>ZettelTitleSelectedMap
-  nnoremap <buffer> gZ <Plug>ZettelReplaceFileWithLink
+  xmap <buffer> z <Plug>ZettelNewSelectedMap
+  xmap <buffer> g[ <Plug>ZettelTitleSelectedMap
+  nmap <buffer> gZ <Plug>ZettelReplaceFileWithLink
 endif


### PR DESCRIPTION
At least in ViM (I'm still stuck on 8.2 here) it seems you cannot create a mapping from a key to a <Plug> with "noremap", they need to be the regular version.