### PR TITLE
Add a test framework based on vader.vim

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,11 +4,9 @@ This folder contains the tests for the vim-zettel plugin.
 The tests run with a dedicated vimrc (`./test_vimrc`), which specifies minimal settings and configures vimwiki and vim-zettel to use the wikis under `./resources/`.
 
 ## Prerequisites
-- Install `vader`, `vimwiki`, `vim-zettel`.
-- Create a file named `rtp.vim` under `tests/`.
-- Add the plugins installation path to the `rtp`.
-
-E.g.: (adjust the paths as needed)
+- Install `vader`, `vimwiki`, `vim-zettel`
+- Create a file named `rtp.vim` under `tests/`
+- In `tests/rtp.vim`, add the plugins installation path to the `rtp`: (adjust the paths as needed)
 ```vim
 set rtp+=~/.vim/pack/test-tools/start/vader.vim
 set rtp+=~/.vim/pack/zettel-plugins/start/vimwiki
@@ -16,7 +14,7 @@ set rtp+=~/.vim/pack/zettel-plugins/start/vim-zettel
 ```
 
 ## Run the tests
-To run all tests, change your working directory to `tests/` and issue the command
+To run all tests, change your working directory to `tests/` and issue the command:
 ```bash
 vim -u test_vimrc -i NONE -c "Vader *"
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,31 @@
+This folder contains the tests for the vim-zettel plugin.
+
+# How to run the tests
+The tests run with a dedicated vimrc (`./test_vimrc`), which specifies minimal settings and configures vimwiki and vim-zettel to use the wikis under `./resources/`.
+
+## Prerequisites
+- Install `vader`, `vimwiki`, `vim-zettel`.
+- Create a file named `rtp.vim` under `tests/`.
+- Add the plugins installation path to the `rtp`.
+
+E.g.: (adjust the paths as needed)
+```vim
+set rtp+=~/.vim/pack/test-tools/start/vader.vim
+set rtp+=~/.vim/pack/zettel-plugins/start/vimwiki
+set rtp+=~/.vim/pack/zettel-plugins/start/vim-zettel
+```
+
+## Run the tests
+To run all tests, change your working directory to `tests/` and issue the command
+```bash
+vim -u test_vimrc -i NONE -c "Vader *"
+```
+This starts vim:
+- with `test_vimrc` as `.vimrc` (`-u test_vimrc`)
+- with no `.viminfo` file (`-i NONE`)
+- and issues the Ex command `:Vader *` (`-c "Vader *"`), which will execute all `*.vader` files
+
+### CAUTION :warning:
+If you want to run the tests from vim with `:Vader *`, make sure to start vim with the `./test_vimrc` (`vim -u ./test_vimrc`).
+Otherwise the tests (potentially destructive) will run on your wiki list.
+

--- a/tests/resources/templ.tpl
+++ b/tests/resources/templ.tpl
@@ -1,0 +1,5 @@
+go back: %backlink
+
+# %title
+
+type: %type

--- a/tests/rtp.vim
+++ b/tests/rtp.vim
@@ -1,4 +1,0 @@
-set rtp+=~/.vim/pack/test/start/vader.vim
-set rtp+=~/.vim/pack/myzettel/start/vimwiki
-set rtp+=~/.vim/pack/myzettel/start/vim-zettel
-

--- a/tests/rtp.vim
+++ b/tests/rtp.vim
@@ -1,0 +1,4 @@
+set rtp+=~/.vim/pack/test/start/vader.vim
+set rtp+=~/.vim/pack/myzettel/start/vimwiki
+set rtp+=~/.vim/pack/myzettel/start/vim-zettel
+

--- a/tests/test_vimrc
+++ b/tests/test_vimrc
@@ -1,0 +1,28 @@
+" Determine absolute path of the `tests/` folder
+let TEST_DIR_PATH = expand('<sfile>:p:h')
+
+" Discover the rtp configuration file
+let rtp_file = TEST_DIR_PATH."/"."rtp.vim"
+if filereadable(rtp_file)
+	execute 'source ' . rtp_file
+else
+	echohl WarningMsg
+	echo 'Define a file named `rtp.vim`, setting the rtp for vader, vimwiki and vim-zettel!'
+       	echohl None
+	finish
+endif
+
+" cleanup files generated during previous test run
+call system('rm -f  '.TEST_DIR_PATH.'/resources/tmp-wiki/*')
+
+" vimrc configuration
+filetype plugin indent on
+syntax enable
+set nocompatible
+
+let vimwiki_markdown = {}
+let vimwiki_markdown.path = TEST_DIR_PATH .'/resources/tmp-wiki'
+let vimwiki_markdown.syntax = 'markdown'
+let vimwiki_markdown.ext = '.md'
+
+let g:vimwiki_list = [ vimwiki_markdown ] 

--- a/tests/zettel_creation.vader
+++ b/tests/zettel_creation.vader
@@ -1,0 +1,98 @@
+Before (Open wiki index and go to beginning of the file):
+  VimwikiIndex
+  execute "normal! gg"
+
+--------------------------------------------------------------------------------
+Do (create new zettel with z):
+  cc
+  new zettel with default settings\<Esc>
+  0wwv3ez\<CR>
+
+Then (new zettel with default frontmatter has been created):
+  :let date=strftime('%Y-%m-%d %H:%M')
+  :AssertEqual '---', getline(1)
+  :AssertEqual 'title: with default settings', getline(2)
+  :AssertEqual 'date: '.date, getline(3)
+  :AssertEqual '---', getline(4)
+
+--------------------------------------------------------------------------------
+Do (check index.md):
+  k
+
+Then (link has been created in place of highlighted text):
+  :AssertEqual 'new zettel [with default settings]('.strftime('%y%m%d-%H%M').')', getline(1)
+
+--------------------------------------------------------------------------------
+Execute (define front_matter):
+  let zo_markdown = {}
+  let zo_markdown.front_matter = [ ["tags", ""], ["type", "note"] ]
+  let g:zettel_options = [ zo_markdown ]
+  Log 'zettel_options: ' . string(g:zettel_options)
+
+Do (create new zettel with z):
+  Go
+  zettel with user defined frontmatter\<Esc>
+  0wwv3ez\<CR>
+
+Then (new zettel with user defined frontmatter has been created):
+  :let date=strftime('%Y-%m-%d %H:%M')
+  :AssertEqual '---', getline(1)
+  :AssertEqual 'title: user defined frontmatter', getline(2)
+  :AssertEqual 'date: '.date, getline(3)
+  :AssertEqual 'tags: ', getline(4)
+  :AssertEqual 'type: note', getline(5)
+  :AssertEqual '---', getline(6)
+
+--------------------------------------------------------------------------------
+Execute (define template):
+  let zo_markdown = {}
+  let zo_markdown.template = "./resources/templ.tpl"
+  let g:zettel_options = [ zo_markdown ]
+  Log 'zettel_options: ' . string(g:zettel_options)
+
+Do (create new zettel with z):
+  Go
+  zettel with user defined template\<Esc>
+  0wwv3ez\<CR>
+
+Then (new zettel with default frontmatter and template has been created):
+  :let date=strftime('%Y-%m-%d %H:%M')
+  :AssertEqual '---', getline(1)
+  :AssertEqual 'title: user defined template', getline(2)
+  :AssertEqual 'date: '.date, getline(3)
+  :AssertEqual '---', getline(4)
+  :AssertEqual '', getline(5)
+  :AssertEqual 'go back: [index](index)', getline(6)
+  :AssertEqual '', getline(7)
+  :AssertEqual '# user defined template', getline(8)
+  :AssertEqual '', getline(9)
+  :AssertEqual 'type: %type', getline(10)
+
+--------------------------------------------------------------------------------
+Execute (define front_matter and template):
+  let zo_markdown = {}
+  let zo_markdown.front_matter = [ ["tags", ""], ["type", "note"] ]
+  let zo_markdown.template = "./resources/templ.tpl"
+  let g:zettel_options = [ zo_markdown ]
+  Log 'zettel_options: ' . string(g:zettel_options)
+
+Do (create new zettel with z):
+  Go
+  zettel with frontmatter and template\<Esc>
+  0wwv3ez\<CR>
+
+Then (new zettel with user defined frontmatter and template has been created):
+  :let date=strftime('%Y-%m-%d %H:%M')
+  :AssertEqual '---', getline(1)
+  :AssertEqual 'title: frontmatter and template', getline(2)
+  :AssertEqual 'date: '.date, getline(3)
+  :AssertEqual 'tags: ', getline(4)
+  :AssertEqual 'type: note', getline(5)
+  :AssertEqual '---', getline(6)
+  :AssertEqual '', getline(7)
+  :AssertEqual 'go back: [index](index)', getline(8)
+  :AssertEqual '', getline(9)
+  :AssertEqual '# frontmatter and template', getline(10)
+  :AssertEqual '', getline(11)
+  :AssertEqual 'type: note', getline(12)
+


### PR DESCRIPTION
This pull-request adds a test framework based on [vader.vim](https://github.com/junegunn/vader.vim).

I've setup a dedicated minimal `.vimrc` to isolate test runs from the wikis specified in the user `g:vimwiki_list`.
A detailed explanation of how to run the tests can be found in `tests/README.md`.

I've set up only a few tests for:
- zettel creation
- replacement of highlighted text with link (markdown) 
- zettel creation with/without user defined template and frontmatter

I hope this can be a first step in helping others adding new functionalities, without breaking anything.