### PR TITLE
Fix link generation when wiki extension has multiple dots

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -403,7 +403,7 @@ endfunction
 " find title in the zettel file and return correct link to it
 function! zettel#vimwiki#get_link(filename)
   let title =zettel#vimwiki#get_title(a:filename)
-  let wikiname = fnamemodify(a:filename, ":t:r")
+  let wikiname = vimwiki#vars#get_bufferlocal('subdir') . substitute(fnamemodify(a:filename, ":t"), vimwiki#vars#get_wikilocal('ext', vimwiki#vars#get_bufferlocal('wiki_nr')) . '$' , '', '')
   if title == ""
     " use the Zettel filename as title if it is empty
     let title = wikiname


### PR DESCRIPTION
When using extension containing multiple dots, for example `.wiki.txt`, generated links would be faulty links by ending with piece of the extension, for example `.wiki`, then vimwiki would try to go to a file that ends with `.wiki.wiki.txt` instead.

This patch solves the issue by removing the exact suffix of the extension instead of using the root filename modifier.