### PR TITLE
Fix erronerous links with extention contains dot

### DIFF
--- a/autoload/zettel/fzf.vim
+++ b/autoload/zettel/fzf.vim
@@ -28,8 +28,8 @@ endfunction
 
 " get clean wiki name from a filename
 function! s:get_wiki_file(filename)
-   let fileparts = split(a:filename, '\V.')
-   return join(fileparts[0:-2],".")
+  return substitute(a:filename, vimwiki#vars#get_wikilocal('ext', vimwiki#vars#get_bufferlocal('wiki_nr')) . '$' , '', '')
+
 endfunction
 
 function! s:get_line_number(line)


### PR DESCRIPTION
Directly use the wiki extension setting instead of removing last dot.

# Reproduciton steps

Set wiki extension to `.wiki.txt`:
```
let g:vimwiki_list = [{
            \"path": $REDACTED."/Wiki",
            \"path_html": $REDACTED."/Wiki_html",
            \'template_path': $REDACTED."/Wiki_html_assets",
            \'template_default': 'default',
            \'template_ext': '.html',
            \'generated_links_caption': 1,
            \'auto_export': 1,
            \'auto_toc': 0,
            \'auto_diary_index': 1,
            \'auto_generate_links': 1,
            \'auto_generate_tags': 1,
            \'maxhi': 1,
            \'syntax': 'default',
            \'ext': '.wiki.txt',
            \'index': 'index',
            \'auto_tags': 1}]
```

Create a note with filename "2024-04-30.wiki.txt"
Edit another wiki note, in insert mode  `[[` search for previous note to insert a link.

# Before this patch

Link inserted `[[2024-04-30.wiki|Content]]` does not work

# After this patch

Link inserted `[[2024-04-30|Content]]` works