### PR TITLE
RFC: use external grep

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -463,7 +463,8 @@ function! zettel#vimwiki#wikigrep(pattern)
   let ext = vimwiki#vars#get_wikilocal('ext', idx)
   " Assume this grepprg has dash l flag
   let command = &grepprg . ' -l ' . a:pattern . ' -r ' . path . " *" . ext
-  let paths = systemlist(command)
+  " Needs trimming on windows, see `:h systemlist`
+  let paths = systemlist(l:command)->map('trim(v:val)')
   return paths
 endfunction
 

--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -124,7 +124,7 @@ else
   let s:header_format = "%%%s %s"
   let s:header_delimiter = ""
   let s:insert_mode_title_format = "h"
-  let s:grep_link_pattern = '/\[.*%s[|#\]]/'
+  let s:grep_link_pattern = '"\[\[.*%s.*\]\]"'
 
   let s:section_pattern = "= %s ="
 endif
@@ -461,17 +461,9 @@ function! zettel#vimwiki#wikigrep(pattern)
   let idx = vimwiki#vars#get_bufferlocal('wiki_nr')
   let path = fnameescape(zettel#vimwiki#path(idx))
   let ext = vimwiki#vars#get_wikilocal('ext', idx)
-  try
-    let command = 'vimgrep ' . a:pattern . 'j ' . path . "**/*" . ext
-    noautocmd  execute  command
-  catch /^Vim\%((\a\+)\)\=:E480/   " No Match
-    "Ignore it, and move on to the next file
-  endtry
-  for d in getqflist()
-    let filename = fnamemodify(bufname(d.bufnr), ":p")
-    call add(paths, filename)
-  endfor
-  call uniq(paths)
+  " Assume this grepprg has dash l flag
+  let command = &grepprg . ' -l ' . a:pattern . ' -r ' . path . " *" . ext
+  let paths = systemlist(command)
   return paths
 endfunction
 

--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -462,7 +462,10 @@ function! zettel#vimwiki#wikigrep(pattern)
   let path = fnameescape(zettel#vimwiki#path(idx))
   let ext = vimwiki#vars#get_wikilocal('ext', idx)
   " Assume this grepprg has dash l flag
-  let command = &grepprg . ' -l ' . a:pattern . ' -r ' . path . " *" . ext
+  " this is for ag, but I could not make ag works on windows because of output encoding
+  "let command = &grepprg . ' -l ' . a:pattern . ' -r ' . path . " *" . ext
+  " this is for rg, and works great on windows
+  let l:command = &grepprg . ' -l ' . a:pattern . ' ' . path . " --glob=*" . ext
   " Needs trimming on windows, see `:h systemlist`
   let paths = systemlist(l:command)->map('trim(v:val)')
   return paths

--- a/doc/zettel.txt
+++ b/doc/zettel.txt
@@ -168,16 +168,14 @@ with the given order.
                                                        *ZettelNewSelectedMap*
 - `:ZettelNewSelectedMap` creates a new note with the selected title while
   converting the selection as a link to the newly created zettel. If you want
-  to replace the selected text about foo with a new zettel containing the
-  selection, you can do 
+  the selection to be the note's content instead, see ZettelCaptureSelected.
 
-    1. select lines about foo
-    2. delete
-    3. write a title for the new note
-    4. select the title
-    5. press z, which calls `ZettelNewSelectedMap` and creates a new note
-       with the selected title
-    6. paste the deleted content
+                                           *Vim-Zettel_ZettelCaptureSelected*
+                                                      *ZettelCaptureSelected*
+- `:ZettelCaptureSelected(title)` creates a new note with the selected content
+  and the title passed as a parameter. The selection is converted to a link
+  to the newly created zettel. If you want the selected text to be the title
+  instead, see ZettelNewSelectedMap.
 
                                              *Vim-Zettel_ZettelSetActiveWiki*
                                                         *ZettelSetActiveWiki*


### PR DESCRIPTION
I cut corners here by:
1. assuming grepprg is not vimgrep
2. assuming grepprg is compatible with grep (-l, -r, etc.)

Here I profile the time spent in zettel#vimwiki#backlinks on my personal wiki folder:

- before: backlinks takes 1.170s
- after:  backlinks takes 0.096s
- 
fixes https://github.com/michal-h21/vim-zettel/issues/154