### PR TITLE
Correctly format link name in zettel_new_selected()

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -701,7 +701,6 @@ function! zettel#vimwiki#zettel_new_selected()
     let idx = a:0 ? a:1 : vimwiki#vars#get_bufferlocal('wiki_nr')
     let prefix =  zettel#vimwiki#get_option('rel_path', idx)
     let name = "/" . prefix . name
-    let linktitle = prefix . linktitle
     execute "normal! :'<,'>s:\\%V.*\\%V.:" . zettel#vimwiki#format_link( name, linktitle) ."\<cr>\<C-o>"
   else
     " if we are in zettelkasten, we should get absolute path anyway, but we


### PR DESCRIPTION
The prior logic would place the rel_path in the link name, making the path and link name identical. Remove this behavior to make the link name match the text as it was highlighted.