### PR TITLE
ZettelCaptureSelected now captures the whole selection

### DIFF
--- a/autoload/zettel/vimwiki.vim
+++ b/autoload/zettel/vimwiki.vim
@@ -17,6 +17,14 @@ function! zettel#vimwiki#get_visual_selection()
   return <sid>get_visual_selection()
 endfunction
 
+function! s:replace_visual_selection(text) abort
+  let save_reg = getreg('z')
+  let save_type = getregtype('z')
+  call setreg('z', a:text, 'c')
+  execute "normal! gv\"zp"
+  call setreg('z', save_reg, save_type)
+endfunction
+
 " this function is useful for comands in plugin/zettel.vim
 " set number of the active wiki
 function! zettel#vimwiki#set_active_wiki(number)
@@ -744,26 +752,27 @@ function! zettel#vimwiki#zettel_new_selected()
   call zettel#vimwiki#zettel_new(title, variables)
 endfunction
 
-function! zettel#vimwiki#zettel_capture_selected(title)
+function! zettel#vimwiki#zettel_capture_selected(...)
   let selection = zettel#vimwiki#get_visual_selection()
-  let title = a:title
+  let title = a:0 ? a:1 : input('Zettel title: ')
+  if empty(title)
+    let title = g:zettel_default_title
+  endif
   let name = zettel#vimwiki#new_zettel_name(title)
   " prepare_template_variables needs the file saved on disk
   execute "write"
   " make variables that will be available in the new page template
   let variables = zettel#vimwiki#prepare_template_variables(expand("%"), title)
-  let linktitle = "\\\\0"
+  let linktitle = title
   if match(vimwiki#path#current_wiki_file(), zettel#vimwiki#path()) != 0
     " if we are NOT in the zettelkasten, we should use absolute (vimwiki
     " root-relative absolute) paths for the name
     let idx = a:0 ? a:1 : vimwiki#vars#get_bufferlocal('wiki_nr')
     let prefix =  zettel#vimwiki#get_option('rel_path', idx)
     let name = "/" . prefix . name
-    let linktitle = prefix . linktitle
   endif
   " replace the visually selected text with a link to the new zettel
-  " \\%V.*\\%V. should select the whole visual selection
-  execute "normal! :'<,'>s:\\%V.*\\%V.:" . zettel#vimwiki#format_link( name, linktitle) ."\<cr>\<C-o>"
+  call s:replace_visual_selection(zettel#vimwiki#format_link(name, linktitle))
   call zettel#vimwiki#zettel_new(title, variables)
   " paste selection at end of file
   execute "normal! Go" . selection

--- a/ftplugin/vimwiki/zettel.vim
+++ b/ftplugin/vimwiki/zettel.vim
@@ -49,7 +49,6 @@ nnoremap <silent> <Plug>ZettelSearchMap :ZettelSearch<cr>
 nnoremap <silent> <Plug>ZettelYankNameMap :ZettelYankName<cr> 
 nnoremap <silent> <Plug>ZettelReplaceFileWithLink :call <sid>replace_file_with_link()<cr> 
 xnoremap <silent> <Plug>ZettelNewSelectedMap :call zettel#vimwiki#zettel_new_selected()<CR>
-xnoremap <silent> <Plug>ZettelCaptureSelected :call zettel#vimwiki#zettel_capture_selected()<CR>
 
 " make fulltext search in all VimWiki files using FZF and insert link to the
 " found file

--- a/plugin/zettel.vim
+++ b/plugin/zettel.vim
@@ -8,6 +8,10 @@ let g:loaded_zettel = 1
 command! -nargs=? -bang ZettelCapture
       \ call zettel#vimwiki#zettel_capture(<q-args>)
 
+command! -range -nargs=* ZettelCaptureSelected
+      \ call call('zettel#vimwiki#zettel_capture_selected',
+      \           empty(<q-args>) ? [] : [<q-args>])
+
 " make fulltext search in all VimWiki files using FZF
 " command! -bang -nargs=* ZettelSearch call fzf#vim#ag(<q-args>, 
 command! -bang -nargs=* ZettelInsertNote call zettel#fzf#execute_fzf(<q-args>, 
@@ -24,4 +28,3 @@ command! -bang -nargs=* ZettelOpen call zettel#fzf#sink_onefile(<q-args>, 'zette
 
 " crate new zettel using command
 command! -bang -nargs=* ZettelNew call zettel#vimwiki#zettel_new(<q-args>)
-


### PR DESCRIPTION
and collapse the selected text it into a single link to the captured zettel instead of changing each line individually.